### PR TITLE
add draw distance to debug tools & dance of knives to rogue rotation

### DIFF
--- a/scripts/debug_tools/main.lua
+++ b/scripts/debug_tools/main.lua
@@ -21,6 +21,8 @@ local menu_elements = {
     future_position_time_slider = slider_float:new(0.1, 2.0, 0.5, get_hash("debug_module_unique_id_gameobjects_debug_future_position_time_slider")),
     future_position_radius_slider = slider_float:new(0.2, 2.0, 0.5, get_hash("debug_module_unique_id_gameobjects_debug_future_position_radius_slider")),
 
+    show_distance = checkbox:new(false, get_hash("debug_module_unique_id_gameobjects_debug_show_distance_checkbox")),
+
     -- Local Player Debug
     local_player_debug_tree = tree_node:new(1),
     draw_map_info_checkbox = checkbox:new(false, get_hash("debug_module_unique_id_localplayer_debug_draw_map_info_checkbox")),
@@ -95,6 +97,8 @@ local function render_menu()
                     menu_elements.future_position_time_slider:render("Time", "Set the time ahead for future position", 2)
                     menu_elements.future_position_radius_slider:render("Radius", "Set the radius for the future position circle", 2)
                 end
+
+                menu_elements.show_distance:render("Show Distance", "Toggle drawing distance to objects")
 
                 if menu_elements.gameobjects_settings_tree:push("Name Filter") then
                     menu_elements.name_filter_input:render("Filter Text", "Enter text to filter objects by name", true, "Go to Input", "Name Text Filter")
@@ -229,6 +233,22 @@ local function draw_object_future_position(obj, player_position, max_distance)
     end
 end
 
+local function draw_object_distance(obj, player_position, max_distance)
+    local show_distance = menu_elements.show_distance:get()
+    if not show_distance then
+        return
+    end
+
+    local object_position = obj:get_position()
+    local distance_to_object = player_position:dist_to(object_position)
+    local distance_text = string.format("%.2f", distance_to_object)
+    local object_position_2d = graphics.w2s(object_position)
+
+    if object_position_2d then
+        graphics.text_2d(distance_text, object_position_2d, 12, color_white(255))
+    end
+end
+
 -- Function to get a list of game objects based on type and affiliation
 local function get_gameobjects_list(type, affiliation)
     local toggle_key = menu_elements.list_toggle:get_key();
@@ -360,6 +380,12 @@ local function draw_object_information(obj, position_2d, player_position, max_di
         position_2d.y = position_2d.y + 15
     end
 
+    -- Drawing Distance
+    if menu_elements.show_distance:get() then
+        draw_object_distance(obj, player_position, max_distance)
+        position_2d.y = position_2d.y + 15
+    end
+
      -- Drawing Interactable State
      if menu_elements.draw_interactable_checkbox:get() then
         local is_interactable = not obj:can_not_interact();
@@ -468,7 +494,11 @@ local function render_visuals()
             local object_position = obj:get_position()
             local distance_to_object_sqr = object_position:squared_dist_to_ignore_z(player_position)
 
-            if distance_to_object_sqr <= (max_distance * max_distance) and not obj:can_not_interact() and (name_filter_text == "" or string.find(object_name, name_filter_text)) then
+            if distance_to_object_sqr 
+            <= (max_distance * max_distance) 
+            --and not obj:can_not_interact() 
+            and (name_filter_text == "" 
+            or string.find(object_name, name_filter_text)) then
                 local object_position_2d = graphics.w2s(object_position)
                 if not object_position_2d then goto continue end
                 local info_position = vec2:new(object_position_2d.x, object_position_2d.y)

--- a/scripts/rotation_rogue/main.lua
+++ b/scripts/rotation_rogue/main.lua
@@ -13,6 +13,7 @@ local menu = require("menu");
 
 local spells =
 {
+    dance_of_knives        = require("spells/dance_of_knives"),
     concealment             = require("spells/concealment"),
     caltrop                 = require("spells/caltrop"),
     puncture                = require("spells/puncture"),
@@ -56,6 +57,7 @@ on_render_menu (function ()
 
     menu.dash_cooldown:render("Dash Cooldown", "");
 
+    spells.dance_of_knives.menu();
     spells.concealment.menu();
     spells.caltrop.menu();
     spells.puncture.menu();

--- a/scripts/rotation_rogue/menu.lua
+++ b/scripts/rotation_rogue/menu.lua
@@ -3,7 +3,7 @@ local menu_elements_bone =
 {
     main_boolean        = checkbox:new(true, get_hash(my_utility.plugin_label .. "main_boolean")),
     mode                = combo_box:new(0, get_hash(my_utility.plugin_label .. "mode_melee_range")),
-    dash_cooldown   = slider_int:new(0, 6, 6, get_hash(my_utility.plugin_label .. "dash_cooldown")),
+    dash_cooldown       = slider_int:new(0, 6, 6, get_hash(my_utility.plugin_label .. "dash_cooldown")),
     main_tree           = tree_node:new(0),
 }
 

--- a/scripts/rotation_rogue/spells/dance_of_knives.lua
+++ b/scripts/rotation_rogue/spells/dance_of_knives.lua
@@ -1,0 +1,79 @@
+local my_utility = require("my_utility/my_utility")
+
+---- MENU
+local menu_elements_dance_of_knives_base =
+{
+    tree_tab            = tree_node:new(1),
+    main_boolean        = checkbox:new(true, get_hash(my_utility.plugin_label .. "main_bool_dance_of_knives_base")),
+}
+
+local function menu()
+    
+    if menu_elements_dance_of_knives_base.tree_tab:push("dance_of_knives")then
+        menu_elements_dance_of_knives_base.main_boolean:render("Enable Spell", "")
+
+        -- if menu_elements_dance_of_knives_base.main_boolean:get() then
+        --     menu_elements_dance_of_knives_base.use_as_filler_only:render("Fury Check", "Prevent casting with a low fury")
+        --  end
+ 
+         menu_elements_dance_of_knives_base.tree_tab:pop()
+    end
+end
+
+
+-- OTHERS
+
+local spell_id_dance_of_knives = 1690398;
+
+local spell_data_dance_of_knives = spell_data:new(
+    0.2,                        -- radius
+    4.0,                        -- range
+    0.01,                       -- cast_delay
+    0.4,                        -- projectile_speed
+    true,                       -- has_collision
+    spell_id_dance_of_knives,   -- spell_id
+    spell_geometry.rectangular, -- geometry_type
+    targeting_type.targeted    --targeting_type
+)
+local next_time_allowed_cast = 0.0;
+local function logics(target)
+    
+    local menu_boolean = menu_elements_dance_of_knives_base.main_boolean:get();
+    local is_logic_allowed = my_utility.is_spell_allowed(
+                menu_boolean, 
+                next_time_allowed_cast, 
+                spell_id_dance_of_knives);
+
+    if not is_logic_allowed then
+        return false
+    end
+
+    local enemies = actors_manager.get_enemy_npcs();
+    local x = 5
+
+    local player_position = get_player_position()
+    local is_wall_collision = target_selector.is_wall_collision(player_position, target, 1.20);
+    if is_wall_collision then
+        return false;
+    end
+
+    for i, enemy in ipairs(enemies) do
+        local enemy_distance = player_position:dist_to(enemy:get_position())
+        if enemy_distance < x then
+            if cast_spell.target(target, spell_data_dance_of_knives, false) then
+                local current_time = get_time_since_inject();
+                next_time_allowed_cast = current_time;
+                console.print("Casted whirl_wind");
+                return true
+            end
+        end
+    end
+    return false
+end
+
+
+return 
+{
+    menu = menu,
+    logics = logics,   
+}


### PR DESCRIPTION
Add distance option to debug tools.
Preliminary dance of knives logic for rogue, taken from the whirlwind logic on the repo.